### PR TITLE
Add .gitattributes to ignore specific files in export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+/.github/                     export-ignore
+/tests/                       export-ignore
+.gitattributes                export-ignore
+.gitignore                    export-ignore
+.php-cs-fixer.dist.php        export-ignore
+.travis.yml                   export-ignore
+README.md                     export-ignore
+php.ini                       export-ignore
+phpstan.neon.dist             export-ignore
+phpunit.xml.dist              export-ignore


### PR DESCRIPTION
also see https://madewithlove.com/blog/gitattributes/
With this PR, The archive targets other than src/ will be as follows:

```
gh api repos/sasezaki/datetime-immutable-factory/tarball/sasezaki-patch-1 | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -v src/
composer.json
```

NOTES: intentionally, I did README.md is also excluded, refer: https://github.com/doctrine/dbal/pull/7272