### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Enforce DateTimeInterface to DateTimeImmutable.
 
+## Status
+
+⚠️ **This library is no longer necessary on PHP 8.0 or later.**
+
+PHP 8.0 introduced `DateTimeImmutable::createFromInterface()`, which provides the same functionality as this library.
+
+If you are using PHP 8.0 or newer, please use the built-in method instead:
+
+https://www.php.net/manual/en/datetimeimmutable.createfrominterface.php
+
 ## Usage
 
 ```php


### PR DESCRIPTION
⚠️ **This library is no longer necessary on PHP 8.0 or later.**

PHP 8.0 introduced `DateTimeImmutable::createFromInterface()`, which provides the same functionality as this library.

If you are using PHP 8.0 or newer, please use the built-in method instead:

https://www.php.net/manual/en/datetimeimmutable.createfrominterface.php